### PR TITLE
fix null value

### DIFF
--- a/src/Query/LastPositionQuery.php
+++ b/src/Query/LastPositionQuery.php
@@ -40,7 +40,7 @@ class LastPositionQuery extends AbstractPositionQuery
         $lastPosition = $query->max($this->model()->getPositionColumn()) ?: 0;
 
         // Check if the last position is not same as original position - the same object
-        if ($lastPosition !== $this->oldPosition) {
+        if (empty($this->oldPosition) || $lastPosition != $this->oldPosition) {
             $this->model()->setPosition($lastPosition + 1);
         }
 

--- a/src/Query/LastPositionQuery.php
+++ b/src/Query/LastPositionQuery.php
@@ -37,10 +37,10 @@ class LastPositionQuery extends AbstractPositionQuery
     public function runQuery($query)
     {
         // Get the last position and move the position
-        $lastPosition = $query->max($this->model()->getPositionColumn());
+        $lastPosition = $query->max($this->model()->getPositionColumn()) ?: 0;
 
         // Check if the last position is not same as original position - the same object
-        if ($lastPosition != $this->oldPosition) {
+        if ($lastPosition !== $this->oldPosition) {
             $this->model()->setPosition($lastPosition + 1);
         }
 


### PR DESCRIPTION
$lastPosition return null if table is empty. 
In mongodb, null values is not saved.