### PR TITLE
Replace removed dispatcher function

### DIFF
--- a/src/PositionObserver.php
+++ b/src/PositionObserver.php
@@ -157,6 +157,6 @@ class PositionObserver
      */
     protected function firePositionedEvent(Model $model)
     {
-        $this->events->fire('eloquent.positioned: '.get_class($model), [$model]);
+        $this->events->dispatch('eloquent.positioned: '.get_class($model), [$model]);
     }
 }


### PR DESCRIPTION
The `Illuminate\Events\Dispatcher::fire` method was removed in 5.8.

See: https://laravel.com/docs/5.8/upgrade#events and https://github.com/laravel/framework/pull/26392

This replaces it with the `dispatch` method instead.