### PR TITLE
Change deleted to deleting event in PositionObserver

### DIFF
--- a/src/PositionObserver.php
+++ b/src/PositionObserver.php
@@ -70,7 +70,7 @@ class PositionObserver
      *
      * @param Model|PositionTrait $model
      */
-    public function deleted($model)
+    public function deleting($model)
     {
         if ($model->isPositionUpdateDisabled() === false) {
             // Get the old position


### PR DESCRIPTION
When model uses soft-deletes and last record is deleted, PositionObserver deleted event is called and runs a LastPositionQuery which incorrectly fetches max position (because model is already deleted). 

This change ensures, that fetching last position is done before model is deleted, so recalculate will behave correctly. 